### PR TITLE
Correct inkeys.wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 *This repo houses our website and other static resources.*
 
-We are part of the [https://inkeys.tech](https://inkeys.tech) Discord at [https://discord.gg/fGUjnUuAVQ](https://discord.gg/fGUjnUuAVQ) where a lot of converation happens and our knowledge base is part of [https://inkeys.wiki](https:/inkeys.wiki)
+We are part of the [https://inkeys.tech](https://inkeys.tech) Discord at [https://discord.gg/fGUjnUuAVQ](https://discord.gg/fGUjnUuAVQ) where a lot of converation happens and our knowledge base is part of [https://inkeys.wiki](https://inkeys.wiki)
 
 We hope to see you about!


### PR DESCRIPTION
I keep forgetting the link is broken and getting redirected to github.com/inkeys.wiki